### PR TITLE
DEV-667 - add mb + ls + prepare the way for debug=local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,12 @@ pt/
 sample-data/
 slip/
 ssd/
+ping/
+mb/
+ls/
+mdp-lib/
+plack-lib/
+slip-lib/
+mdp-web/
 logs/
 cache/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,13 @@ services:
       - ./cache:/htapps/babel/cache
       - ./pt:/htapps/babel/pt
       - ./ssd:/htapps/babel/ssd
+      - ./ping:/htapps/babel/ping
+      - ./mb:/htapps/babel/mb
+      - ./ls:/htapps/babel/ls
       - ./common:/htapps/babel/common
+      - ./mdp-lib:/htapps/babel/mdp-lib
+      - ./slip-lib:/htapps/babel/slip-lib
+      - ./plack-lib:/htapps/babel/plack-lib
       - "./sample-data/sdr1:/sdr1"
       - "./sample-data/etc:/htapps/babel/etc"
       - "./sample-data/watermarks:/htapps/babel/watermarks"
@@ -98,6 +104,7 @@ services:
     volumes:
       - ./slip/etc/sql/100_slip.sql:/docker-entrypoint-initdb.d/100_slip.sql
       - ./catalog/docker/vufind.sql:/docker-entrypoint-initdb.d/101_vufind.sql
+      - ./mb/etc/sql/999_mb.sql:/docker-entrypoint-initdb.d/999_mb.sql
     ports:
       - "3307:3306"
 

--- a/docker/babel-base/Dockerfile
+++ b/docker/babel-base/Dockerfile
@@ -51,8 +51,11 @@ RUN cpanm --notest \
   URI::Escape \
   CGI::PSGI \
   IP::Geolocation::MMDB \
-  UUID
-
+  UUID \
+  UUID::Tiny \
+  YAML::Any \
+  Data::Page
+  
 WORKDIR /htapps/babel/geoip
 ADD --chmod=644 https://github.com/maxmind/MaxMind-DB/blob/main/test-data/GeoIP2-Country-Test.mmdb?raw=true GeoIP2-Country.mmdb
 

--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -87,11 +87,15 @@ server {
 
   location /cgi/imgsrv {
     # rewrite /cgi/pt/(.*)$ /cgi/pt/$1 break;
+    proxy_set_header Host            $host;
+    proxy_set_header X-Forwarded-For $remote_addr;
     proxy_pass http://apache-cgi:41028/cgi/imgsrv;
   }
 
   location /cgi/pt {
     # rewrite /cgi/pt/(.*)$ /cgi/pt/$1 break;
+    proxy_set_header Host            $host;
+    proxy_set_header X-Forwarded-For $remote_addr;
     proxy_pass http://apache-cgi:41028/cgi/pt;
   }
 
@@ -102,12 +106,50 @@ server {
 
   location /cgi/ssd {
     # rewrite /cgi/pt/(.*)$ /cgi/pt/$1 break;
+    proxy_set_header Host            $host;
+    proxy_set_header X-Forwarded-For $remote_addr;
     proxy_pass http://apache-cgi:41028/cgi/ssd;
   }
 
   location /ssd {
     rewrite /ssd/(.*)$ /ssd/$1 break;
     proxy_pass http://apache-cgi:41028/ssd;
+  }
+
+  location /cgi/ping {
+    # rewrite /cgi/pt/(.*)$ /cgi/pt/$1 break;
+    proxy_set_header Host            $host;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_pass http://apache-cgi:41028/cgi/ping;
+  }
+
+  # location /ping {
+  #   rewrite /ping/(.*)$ /ping/$1 break;
+  #   proxy_pass http://apache-cgi:41028/ping;
+  # }
+
+  location /cgi/mb {
+    # rewrite /cgi/pt/(.*)$ /cgi/pt/$1 break;
+    proxy_set_header Host            $host;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_pass http://apache-cgi:41028/cgi/mb;
+  }
+
+  location /mb {
+    rewrite /mb/(.*)$ /mb/$1 break;
+    proxy_pass http://apache-cgi:41028/mb;
+  }
+
+  location /cgi/ls {
+    # rewrite /cgi/pt/(.*)$ /cgi/pt/$1 break;
+    proxy_set_header Host            $host;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_pass http://apache-cgi:41028/cgi/ls;
+  }
+
+  location /ls {
+    rewrite /ls/(.*)$ /ls/$1 break;
+    proxy_pass http://apache-cgi:41028/ls;
   }
 
   location / {

--- a/setup.sh
+++ b/setup.sh
@@ -23,10 +23,17 @@ git clone --recurse-submodules $GIT_BASE/imgsrv-sample-data ./sample-data
 git clone --recurse-submodules $GIT_BASE/catalog
 git clone --recurse-submodules $GIT_BASE/common
 git clone --recurse-submodules $GIT_BASE/pt
+git clone --recurse-submodules $GIT_BASE/mb
+git clone --recurse-submodules $GIT_BASE/ls
+git clone --recurse-submodules $GIT_BASE/ping
 git clone --recurse-submodules $GIT_BASE/ssd
 git clone --recurse-submodules $GIT_BASE/hathitrust_catalog_indexer
 git clone --recurse-submodules $GIT_BASE/slip
 git clone --recurse-submodules $GIT_BASE/lss_solr_configs
+git clone --recurse-submodules $GIT_BASE/mdp-lib
+git clone --recurse-submodules $GIT_BASE/plack-lib
+git clone --recurse-submodules $GIT_BASE/slip-lib
+git clone --recurse-submodules $GIT_BASE/mdp-web
 
 echo "CURRENT_USER=$(id -u):$(id -g)" >> .env
 echo "APACHE_RUN_USER=$(id -u)" >> .env


### PR DESCRIPTION
Made a PR because this depends on DEV-664 to be merged.

* adds support for the missing HTDL applications (that matter, no `gr`)
* clones the submodule repos to the root: next step `debug=local`
* passes the host to `apache-cgi` so cookies can be set to the correct domain
