### PR TITLE
Updated Docker Compose for front-end work

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,17 @@ Not yet configured:
 To rebuild the CSS and JavaScript for `firebird-common` and `pt`:
 
 ```bash
- build firebird-common
-docker compose run node /htapps/babel/firebird-common/bin/build.sh
+#build firebird-common
+docker compose run firebird /htapps/babel/firebird-common/bin/build.sh
 
 # build pt/firebird
-docker compose run node /htapps/babel/pt/bin/build.sh
+docker compose run page-turner /htapps/babel/pt/bin/build.sh
+```
+
+To stand up a development environment while working strictly on the front-end.
+
+```bash
+docker compose --profile node up
 ```
 
 ## Staging an Item
@@ -109,7 +115,7 @@ to the local repository, and index it in the local full-text index. You should
 then be able to view it via for example
 http://localhost:8080/cgi/pt?id=uc2.ark:/13960/t4mk66f1d
 
-## Database Utilities 
+## Database Utilities
 
 ### Resetting / updating database & solr schema
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,17 @@
-version: '3'
+version: '3.8'
 
 name: babel-firebird
+
+x-node: &node
+    image: node:18-slim
+    user: ${CURRENT_USER}
+    profiles:
+      - node
+    volumes:
+      - ${BABEL_HOME}/firebird-common:/htapps/babel/firebird-common
+      - ${BABEL_HOME}/pt:/htapps/babel/pt
+      - ${BABEL_HOME}/.npm:/.npm
+
 
 services:
 
@@ -90,18 +101,19 @@ services:
       - mysql-sdr
       - solr-sdr-catalog
 
-  node:
-    image: node:18-slim
-    user: ${CURRENT_USER}
-    profiles:
-      - node
-    volumes:
-      - ${BABEL_HOME}/firebird-common:/htapps/babel/firebird-common
-      - ${BABEL_HOME}/pt:/htapps/babel/pt
-      - ${BABEL_HOME}/.npm:/.npm
+  firebird:
+    <<: *node
+    working_dir: /htapps/babel/firebird-common
+    command: ['npm', 'run', 'babel']
+
+  page-turner:
+    <<: *node
+    working_dir: /htapps/babel/pt/web/firebird
+    command: ['npm', 'run', 'babel']
 
 
-#### DATA STORES
+
+### DATA STORES
 
   solr-sdr-catalog:
     image: ghcr.io/hathitrust/catalog-solr-sample

--- a/setup.sh
+++ b/setup.sh
@@ -42,9 +42,9 @@ git clone --recurse-submodules $GIT_BASE/mdp-web
 git clone --recurse-submodules $GIT_BASE/ptsearch-solr
 git clone --recurse-submodules $GIT_BASE/firebird-common
 
-echo 
+echo
 echo 🍃 Setting up the environment...
-echo 
+echo
 
 cat <<EOT | tee .env
 CURRENT_USER="$(id -u):$(id -g)"
@@ -65,8 +65,8 @@ echo
 echo 🐦‍🔥 Building firebird...
 echo
 
-docker compose run node /htapps/babel/firebird-common/bin/build.sh
-docker compose run node /htapps/babel/pt/bin/build.sh
+docker compose run firebird /htapps/babel/firebird-common/bin/build.sh
+docker compose run page-turner /htapps/babel/pt/bin/build.sh
 
 echo
 echo 🎉 Done!


### PR DESCRIPTION
I added two new containers for firebird-common and page-turner. These two containers spin up and listen for changes during the development process. Without then, any dev would have to manually stand up two containers, have them listen for changes in the code, and re-compile everything. This change eliminates those steps.